### PR TITLE
humanized tweets: added comma for view count

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ _testmain.go
 *.exe
 *.test
 *.prof
+
+# Text editor files
+*.sw[op]

--- a/cmd/youtube-popular-bot/main.go
+++ b/cmd/youtube-popular-bot/main.go
@@ -12,6 +12,7 @@ import (
 	"github.com/odeke-em/youtube"
 
 	"github.com/ChimeraCoder/anaconda"
+	"github.com/dustin/go-humanize"
 )
 
 var (
@@ -136,10 +137,13 @@ func periodicTweets(period time.Duration) chan error {
 	return errsChan
 }
 
-const tweetTmplStr = `Rank #{{.Rank}} Views: {{.ViewCount}} Title: {{.Title}} {{youtubeURL .YouTubeId}}`
+const tweetTmplStr = `#{{.Rank}}: {{commafy .ViewCount}} views {{.Title}} {{youtubeURL .YouTubeId}}`
 
 var tmplFuncs = template.FuncMap{
 	"youtubeURL": func(id string) string { return fmt.Sprintf("https://youtu.be/%s", id) },
+	"commafy": func(views uint64) string {
+		return humanize.Comma(int64(views))
+	},
 }
 var tweetTemplate = template.Must(template.New("tweet").Funcs(tmplFuncs).Parse(tweetTmplStr))
 


### PR DESCRIPTION
Humanized tweets by adding commas to views, reformatting
the presentation so that a typical tweet will look like this
```
 #5: 1,083,945 views Big Sean - Moves https://youtu.be/7cIkC7s3d2o
```
Or
https://twitter.com/trends_ebot/status/817270748842573824